### PR TITLE
map Timestamp types to Date types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import { map } from 'rxjs/operators';
-import { MonoTypeOperatorFunction } from 'rxjs';
+import { OperatorFunction } from 'rxjs';
 
 /**
  * rxjs pipe to convert timestamps
  */
-export function convertTimestampsPipe<T>(): MonoTypeOperatorFunction<T> {
+export function convertTimestampsPipe<T>(): OperatorFunction<T, WithTimestampsAsDates<T>> {
 	return input$ => input$.pipe(
 		map( (val:any) => convertTimestamps(val) )
 	);
@@ -14,13 +14,13 @@ export function convertTimestampsPipe<T>(): MonoTypeOperatorFunction<T> {
  * convert any timestamp properties to js date format
  * @param firebaseObject
  */
-export function convertTimestamps<T>(firebaseObject: T|T[]): T|T[] {
-	if (!firebaseObject) return firebaseObject;
+export function convertTimestamps<T>(firebaseObject: T): WithTimestampsAsDates<T> {
+	if (!firebaseObject) return firebaseObject as WithTimestampsAsDates<T>;
 	// if (typeof firebaseObject === 'undefined') return firebaseObject;
 
 	// if an array was passed
 	if (Array.isArray(firebaseObject)) {
-		return firebaseObject.map((item: any) => convertTimestamps(item))
+		return firebaseObject.map((item) => convertTimestamps(item)) as WithTimestampsAsDates<T>
 	}
 
 	// if its a map (object)
@@ -58,35 +58,35 @@ export function convertTimestamps<T>(firebaseObject: T|T[]): T|T[] {
 
 		}
 	}
-	return firebaseObject;
+	return firebaseObject as WithTimestampsAsDates<T>;
 };
 
 /**
  * convert any value
  * @param value
  */
-export function convertTimestamp<T extends object>(value: T): T | Date {
+export function convertTimestamp<T extends object>(value: T): WithTimestampsAsDates<T> {
 	if (value === null || typeof value === 'undefined') return value;
 
 	if (isTimestamp(value)) {
 		try {
-			return (value as Timestamp).toDate();
+			return value.toDate() as WithTimestampsAsDates<T>;
 		} catch {
-			return value;
+			return value as WithTimestampsAsDates<T>;
 		}
 	}
 
-	return value;
+	return value as WithTimestampsAsDates<T>;
 }
 
 /**
  * verify if value is timestamp
  * @param value
  */
-function isTimestamp(value: any): boolean {
-	if (value.hasOwnProperty('seconds') &&
-		value.hasOwnProperty('nanoseconds') &&
-		typeof value.toDate === 'function'
+function isTimestamp(value: any): value is Timestamp {
+	if (value?.hasOwnProperty('seconds') &&
+		value?.hasOwnProperty('nanoseconds') &&
+		typeof value?.toDate === 'function'
 	) {
 		return true;
 	}
@@ -100,3 +100,42 @@ function isTimestamp(value: any): boolean {
 interface Timestamp {
 	toDate(): Date;
 }
+
+type WithTimestampsAsDates<T> = DeepReplace<T, [Timestamp, Date]>;
+
+/**
+ * replace occurrences of `M[x][0]` in `T` with `M[x][1]` recursively
+ * @example
+ * ```
+ * const u: DeepReplace<
+ *   {
+ *     a: {
+ *       b: [Timestamp];
+ *       c: string;
+ *     };
+ *     x: Timestamp;
+ *   },
+ *   [Timestamp, Date]
+ * > = {
+ *   a: {
+ *     b: [new Date()],
+ *     c: "...",
+ *   },
+ *   x: new Date(),
+ * };
+ * ```
+ * @note https://stackoverflow.com/a/60437613
+ */
+type DeepReplace<T, M extends [any, any]> = {
+  [P in keyof T]: T[P] extends M[0]
+    ? Replacement<M, T[P]>
+    : T[P] extends object
+    ? DeepReplace<T[P], M>
+    : T[P];
+};
+
+type Replacement<M extends [any, any], T> = M extends any
+  ? [T] extends [M[0]]
+    ? M[1]
+    : never
+  : never;


### PR DESCRIPTION
## Objective

`convertTimestampsPipe` is mapping from a type A (with Timestamps) to a type B (with Dates). Therefore, a `MonoTypeOperatorFunction` (mapping from A to A) seems strange. With this PR I am introducing a simple type mapping to map Timestamp types to Date types.

## Type

- [X] Bug Fix
- [X] New Feature

## Work Done

* add TS type mapping `DeepReplace` to replace occurrences of `M[x][0]` in `T` with `M[x][1]` recursively
* add type casts
* turn `isTimestamp` into a type guard

---

## Tested

* Previous tests still pass
* No new tests added as the logic has not been changed
* The type generic has been tested manually, see TSDoc example
