### PR TITLE
map Timestamp types to Date types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { map } from 'rxjs/operators';
-import { MonoTypeOperatorFunction } from 'rxjs';
+import { OperatorFunction } from 'rxjs';
 
 /**
  * rxjs pipe to convert timestamps
  */
-export function convertTimestampsPipe<T>(): MonoTypeOperatorFunction<T> {
+export function convertTimestampsPipe<T>(): OperatorFunction<T, WithTimestampsAsDates<T>> {
 	return input$ => input$.pipe(
-		map( (val:any) => convertTimestamps(val) )
+		map( (val:T) => convertTimestamps(val) )
 	);
 }
 
@@ -14,13 +14,17 @@ export function convertTimestampsPipe<T>(): MonoTypeOperatorFunction<T> {
  * convert any timestamp properties to js date format
  * @param firebaseObject
  */
-export function convertTimestamps<T>(firebaseObject: T|T[]): T|T[] {
-	if (!firebaseObject) return firebaseObject;
+export function convertTimestamps<T>(firebaseObject: T): WithTimestampsAsDates<T> {
+	if (!firebaseObject) return firebaseObject as WithTimestampsAsDates<T>;
 	// if (typeof firebaseObject === 'undefined') return firebaseObject;
+
+	if(isTimestamp(firebaseObject)){
+		return convertTimestamp(firebaseObject);
+	}
 
 	// if an array was passed
 	if (Array.isArray(firebaseObject)) {
-		return firebaseObject.map((item: any) => convertTimestamps(item))
+		return firebaseObject.map((item) => convertTimestamps(item)) as unknown as WithTimestampsAsDates<T>
 	}
 
 	// if its a map (object)
@@ -58,35 +62,35 @@ export function convertTimestamps<T>(firebaseObject: T|T[]): T|T[] {
 
 		}
 	}
-	return firebaseObject;
+	return firebaseObject as WithTimestampsAsDates<T>;
 };
 
 /**
  * convert any value
  * @param value
  */
-export function convertTimestamp<T extends object>(value: T): T | Date {
+export function convertTimestamp<T extends object>(value: T): WithTimestampsAsDates<T> {
 	if (value === null || typeof value === 'undefined') return value;
 
 	if (isTimestamp(value)) {
 		try {
-			return (value as Timestamp).toDate();
+			return value.toDate() as WithTimestampsAsDates<T>;
 		} catch {
-			return value;
+			return value as WithTimestampsAsDates<T>;
 		}
 	}
 
-	return value;
+	return value as WithTimestampsAsDates<T>;
 }
 
 /**
  * verify if value is timestamp
  * @param value
  */
-function isTimestamp(value: any): boolean {
-	if (value.hasOwnProperty('seconds') &&
-		value.hasOwnProperty('nanoseconds') &&
-		typeof value.toDate === 'function'
+function isTimestamp(value: any): value is Timestamp {
+	if (value?.hasOwnProperty('seconds') &&
+		value?.hasOwnProperty('nanoseconds') &&
+		typeof value?.toDate === 'function'
 	) {
 		return true;
 	}
@@ -97,6 +101,45 @@ function isTimestamp(value: any): boolean {
 /**
  * helper
  */
-interface Timestamp {
+export interface Timestamp {
 	toDate(): Date;
 }
+
+export type WithTimestampsAsDates<T> = T extends Timestamp? Date : DeepReplace<T, [Timestamp, Date]>;
+
+/**
+ * replace occurrences of `M[x][0]` in `T` with `M[x][1]` recursively
+ * @example
+ * ```
+ * const u: DeepReplace<
+ * 	{
+ * 		a: {
+ * 			b: [Timestamp];
+ * 			c: string;
+ * 		};
+ * 		x: Timestamp;
+ * 	},
+ * 	[Timestamp, Date]
+ * > = {
+ * 	a: {
+ * 		b: [new Date()],
+ * 		c: '...',
+ * 	},
+ * 	x: new Date(),
+ * };
+ * ```
+ * @note https://stackoverflow.com/a/60437613
+ */
+type DeepReplace<T, M extends [any, any]> = {
+	[P in keyof T]: T[P] extends M[0]
+		? Replacement<M, T[P]>
+		: T[P] extends object
+		? DeepReplace<T[P], M>
+		: T[P];
+};
+
+type Replacement<M extends [any, any], T> = M extends any
+	? [T] extends [M[0]]
+		? M[1]
+		: never
+	: never;

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import { expect, assert } from 'chai';
-import { convertTimestamps, convertTimestampsPipe, convertTimestamp } from '../dist/index';
+import { convertTimestamps, convertTimestampsPipe, convertTimestamp, WithTimestampsAsDates, Timestamp } from '../dist/index';
 import { of } from 'rxjs';
 
 describe('ConvertTimeStamp class', () => {
@@ -22,6 +22,12 @@ describe('ConvertTimeStamp class', () => {
 		const returnValue: any = convertTimestamps(param);
 		assert.typeOf(returnValue, 'undefined', 'is string');
 		expect(returnValue).to.equal(param, 'returns the value passed as a parameter');
+	});
+	it('should return Date', () => {
+		const d = Date();
+		const param = { seconds: 1589952118, nanoseconds: 12345, toDate: () => d };
+		const returnValue: any = convertTimestamps(param);
+		expect(returnValue).to.equal(d, 'Check return value');
 	});
 	it('should return array', () => {
 		const d = Date();
@@ -232,5 +238,47 @@ describe('ConvertTimeStamp class', () => {
 		expect(returnValue.days[0].from).to.equal(d, 'Check date value');
 		expect(returnValue.days[1].to).to.equal(d, 'Check date value');
 		expect(returnValue.days[1].from).to.equal(d, 'Check date value');
+	});
+});
+
+describe('TypeScript Mapping', () => {
+	it('should accept Dates in place of Timestamps', () => {
+		const inObject: WithTimestampsAsDates<{ a: Timestamp }> = { a: new Date() };
+		const inArray: WithTimestampsAsDates<Timestamp[]> = [
+			new Date(),
+			new Date(),
+		];
+		const inTupel: WithTimestampsAsDates<[Timestamp, symbol, Timestamp]> = [
+			new Date(),
+			Symbol.for('example'),
+			new Date(),
+		];
+		const asNull: WithTimestampsAsDates<null> = null;
+		const asUndefined: WithTimestampsAsDates<undefined> = undefined;
+		const asSelf: WithTimestampsAsDates<Timestamp> = new Date();
+		const nested: WithTimestampsAsDates<{
+			a: {
+				b: Timestamp[];
+				c: string;
+			};
+			x: Timestamp;
+		}> = {
+			a: {
+				b: [new Date()],
+				c: '...',
+			},
+			x: new Date(),
+		};
+
+		// simply make sure TypeScript acceps the above - no assertions necessary.
+		expect([
+			inObject,
+			inArray,
+			inTupel,
+			asNull,
+			asUndefined,
+			asSelf,
+			nested
+		])
 	});
 });


### PR DESCRIPTION
## Objective

`convertTimestampsPipe` is mapping from a type A (with Timestamps) to a type B (with Dates). Therefore, a `MonoTypeOperatorFunction` (mapping from A to A) seems strange. With this PR I am introducing a simple type mapping to map Timestamp types to Date types.

## Type

- [X] Bug Fix
- [X] New Feature

## Work Done

* add TS type mapping `DeepReplace` to replace occurrences of `M[x][0]` in `T` with `M[x][1]` recursively
* add type casts
* turn `isTimestamp` into a type guard
* add support for `Timestamps` on first level

---

## Tested

* Previous tests still pass
* add new test for first level `Timestamps`
* add unit test without value but type assertions to assure type mappings hold true
